### PR TITLE
Fix docker build failure due to AiraNg download url changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ LABEL maintainer "onisuly <onisuly@gmail.com>"
 
 # For build image faster in China
 # RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories
+ARG http_proxy
+ARG https_proxy
 
 RUN mkdir -p /conf \
     && mkdir -p /data \
@@ -13,7 +15,7 @@ RUN mkdir -p /conf \
 RUN apk add --no-cache --virtual .install-deps curl unzip \
     && mkdir -p /aria2-ng \
     && ng_tag=$(curl -sX GET "https://api.github.com/repos/mayswind/AriaNg/releases/latest" | awk '/tag_name/{print $4;exit}' FS='[""]') \
-    && curl -o /aria2-ng.zip -L https://github.com/mayswind/AriaNg/releases/download/${ng_tag}/aria-ng-${ng_tag}.zip \
+    && curl -o /aria2-ng.zip -L https://github.com/mayswind/AriaNg/releases/download/${ng_tag}/AriaNg-${ng_tag}.zip \
     && unzip /aria2-ng.zip -d /aria2-ng \
     && rm /aria2-ng.zip \
     && apk del .install-deps


### PR DESCRIPTION
Fix docker build failure due to AiraNg download url changed
Add http_proxy and https_proxy build argument for proxy environment.