### PR TITLE
Add heathcheck for darkhttpd. Try to fix aria2 save session failed due to permission denied.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,4 @@ EXPOSE 6800
 EXPOSE 80
 
 CMD ["/preset-conf/start.sh"]
+HEALTHCHECK --interval=5s --timeout=1s CMD ps | grep darkhttpd | grep -v grep || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@ LABEL maintainer "onisuly <onisuly@gmail.com>"
 
 # For build image faster in China
 # RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.ustc.edu.cn/g' /etc/apk/repositories
-ARG http_proxy
-ARG https_proxy
 
 RUN mkdir -p /conf \
     && mkdir -p /data \

--- a/files/start.sh
+++ b/files/start.sh
@@ -32,6 +32,8 @@ if [ ! -f /conf/aria2.conf ]; then
     fi
 fi
 
+chown $PUID:$PGID /conf || echo 'Failed to set owner of /conf, aria2 may not have permission to write /conf/aria2.session'
+
 touch /conf/aria2.session
 chown $PUID:$PGID /conf/aria2.session
 


### PR DESCRIPTION
Add health check for darkhttpd for diagnostic.
Try to fix aria2 save session failed due to permission denied (/conf has no write permission for aria2 running user)