### PR TITLE
Add SECRET_FILE variable and remove file-allocation=falloc

### DIFF
--- a/files/aria2.conf
+++ b/files/aria2.conf
@@ -2,7 +2,6 @@ dir=/data
 input-file=/conf/aria2.session
 save-session=/conf/aria2.session
 
-file-allocation=falloc
 log-level=warn
 enable-http-pipelining=true
 

--- a/files/start.sh
+++ b/files/start.sh
@@ -10,7 +10,10 @@ SEEDTIME=${SEEDTIME:=0}
 if [ ! -f /conf/aria2.conf ]; then
     cp /preset-conf/aria2.conf /conf/aria2.conf
     chown $PUID:$PGID /conf/aria2.conf
-    if [ $SECRET ]; then
+
+    if [ -z "$SECRET" ] && [ -n "$SECRET_FILE" ] && [ -r "$SECRET_FILE" ]; then
+        echo "rpc-secret=$(cat "${SECRET_FILE}")" >> /conf/aria2.conf
+    elif [ -n "$SECRET" ]; then
         echo "rpc-secret=${SECRET}" >> /conf/aria2.conf
     fi
 


### PR DESCRIPTION
Add 'SECRET_FILE' environment variable to support Docker Secrets and removed 'file-allocation=falloc' to fix filesystem incompatibility.
