### PR TITLE
Fix DHT file locations, explicitly set file allocation method and update bt trackers in existing aria2.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker run -d --name aria2-webui \
 onisuly/aria2-with-webui
 ```
 
-Which will make the Aria2 client accessible over HTTP from port 6800, with the WebUI being accessible from 80. If you define SECRET, this token can be used to communicate with the Aria2 daemon. Define SECURE as true and pass the cert and private key, to enable aria2 RPC transport encrypted by SSL/TLS.
+Which will make the Aria2 client accessible over HTTP from port 6800, with the WebUI being accessible from 80. If you define SECRET or [SECRET_FILE](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets "e.g. SECRET_FILE=./aria2-rpc-secret.txt"), this token can be used to communicate with the Aria2 daemon. Define SECURE as true and pass the cert and private key, to enable aria2 RPC transport encrypted by SSL/TLS.
 
 If you want to use your aria2 configuration file, you need to mount the /conf folder to a volume.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker run -d --name aria2-webui \
 onisuly/aria2-with-webui
 ```
 
-Which will make the Aria2 client accessible over HTTP from port 6800, with the WebUI being accessible from 80. If you define SECRET or [SECRET_FILE](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets "e.g. SECRET_FILE=./aria2-rpc-secret.txt"), this token can be used to communicate with the Aria2 daemon. Define SECURE as true and pass the cert and private key, to enable aria2 RPC transport encrypted by SSL/TLS.
+Which will make the Aria2 client accessible over HTTP from port 6800, with the WebUI being accessible from 80. If you define SECRET or [SECRET_FILE](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets "e.g. SECRET_FILE=./aria2-rpc-secret.txt"), this token can be used to communicate with the Aria2 daemon. Define SECURE as true and pass the cert and private key, to enable aria2 RPC transport encrypted by SSL/TLS. Define FILE_ALLOCATION to explicitly set the [file allocation](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-file-allocation "none, prealloc, trunc or falloc") method. 
 
 If you want to use your aria2 configuration file, you need to mount the /conf folder to a volume.
 

--- a/files/aria2.conf
+++ b/files/aria2.conf
@@ -1,6 +1,8 @@
 dir=/data
 input-file=/conf/aria2.session
 save-session=/conf/aria2.session
+dht-file-path=/conf/dht.dat
+dht-file-path6=/conf/dht6.dat
 
 log-level=warn
 enable-http-pipelining=true

--- a/files/start.sh
+++ b/files/start.sh
@@ -24,6 +24,15 @@ if [ ! -f /conf/aria2.conf ]; then
         echo "rpc-private-key=$PRIVATEKEY" >> /conf/aria2.conf
     fi
 
+    if  [ -n "$FILE_ALLOCATION" ]; then
+        case "$FILE_ALLOCATION" in
+            none|prealloc|trunc|falloc)
+                echo "" >> /conf/aria2.conf
+                echo "file-allocation=$FILE_ALLOCATION" >> /conf/aria2.conf            
+            ;;
+        esac
+    fi
+        
     echo "" >> /conf/aria2.conf
     echo "seed-ratio=$SEEDRATIO" >> /conf/aria2.conf
     echo "seed-time=$SEEDTIME" >> /conf/aria2.conf

--- a/files/start.sh
+++ b/files/start.sh
@@ -36,12 +36,13 @@ if [ ! -f /conf/aria2.conf ]; then
     echo "" >> /conf/aria2.conf
     echo "seed-ratio=$SEEDRATIO" >> /conf/aria2.conf
     echo "seed-time=$SEEDTIME" >> /conf/aria2.conf
-    list=`wget -qO- https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt|awk NF|sed ":a;N;s/\n/,/g;ta"`
-    if [ -z "`grep "bt-tracker" /conf/aria2.conf`" ]; then
-        sed -i '$a bt-tracker='${list} /conf/aria2.conf
-    else
-        sed -i "s@bt-tracker.*@bt-tracker=$list@g" /conf/aria2.conf
-    fi
+fi
+
+list=`wget -qO- https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt|awk NF|sed ":a;N;s/\n/,/g;ta"`
+if [ -z "`grep "bt-tracker" /conf/aria2.conf`" ]; then
+    echo "bt-tracker=$list" >> /conf/aria2.conf
+else
+    sed -i "s@bt-tracker.*@bt-tracker=$list@g" /conf/aria2.conf
 fi
 
 chown $PUID:$PGID /conf || echo 'Failed to set owner of /conf, aria2 may not have permission to write /conf/aria2.session'


### PR DESCRIPTION
When aria2c is not running as root the default dht.dat file location is inaccessible.

The file allocation method can be very important depending on the file system your using and the default is very inefficient.

BitTorrent trackers where not being updated when an aria2.conf already existed.