### PR TITLE
Update bt-trackers using crond, add IPv6 support option and harden darkhttpd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ LABEL maintainer "onisuly <onisuly@gmail.com>"
 RUN mkdir -p /conf \
     && mkdir -p /data \
     && mkdir -p /preset-conf \
-    && apk add --no-cache tzdata bash darkhttpd s6 ca-certificates gnutls expat sqlite-libs c-ares zlib nettle libssh2 libgcc libstdc++
+    && apk add --no-cache tzdata bash darkhttpd s6 ca-certificates gnutls expat sqlite-libs c-ares zlib nettle libssh2 libgcc libstdc++ curl
 
 FROM base AS build
 
@@ -39,8 +39,10 @@ COPY --from=build /aria2-ng /aria2-ng
 
 COPY files/start.sh /preset-conf/start.sh
 COPY files/aria2.conf /preset-conf/aria2.conf
+COPY files/bt-tracker /etc/periodic/daily/bt-tracker
 
 RUN chmod +x /preset-conf/start.sh
+RUN chmod +x /etc/periodic/daily/bt-tracker
 
 WORKDIR /
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ docker run -d --name aria2-webui \
 onisuly/aria2-with-webui
 ```
 
-Which will make the Aria2 client accessible over HTTP from port 6800, with the WebUI being accessible from 80. If you define SECRET or [SECRET_FILE](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets "e.g. SECRET_FILE=./aria2-rpc-secret.txt"), this token can be used to communicate with the Aria2 daemon. Define SECURE as true and pass the cert and private key, to enable aria2 RPC transport encrypted by SSL/TLS. Define FILE_ALLOCATION to explicitly set the [file allocation](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-file-allocation "none, prealloc, trunc or falloc") method. 
+Which will make the Aria2 client accessible over HTTP from port 6800, with the WebUI being accessible from 80. If you define SECRET or [SECRET_FILE](https://docs.docker.com/compose/compose-file/compose-file-v3/#secrets "e.g. SECRET_FILE=./aria2-rpc-secret.txt"), this token can be used to communicate with the Aria2 daemon. Define SECURE as true and pass the cert and private key, to enable aria2 RPC transport encrypted by SSL/TLS.
 
-If you want to use your aria2 configuration file, you need to mount the /conf folder to a volume.
+The [file allocation](https://aria2.github.io/manual/en/html/aria2c.html#cmdoption-file-allocation "none, prealloc, trunc or falloc") method can be defined with FILE_ALLOCATION and IPv6 support can be enabled by defining IPV6 as true.
+
+If you want to use your own aria2 configuration file, you need to mount the /conf folder to a volume.
 
 ## Docker Compose
 ```yaml
@@ -52,6 +54,8 @@ services:
       - SECURE=true
       - CERTIFICATE=/server/path/to/your_cert
       - PRIVATEKEY=/server/path/to/your_key
+      - FILE_ALLOCATION=falloc
+      - IPV6=true
     volumes:
       - /path/to/persist/data:/data
 ```

--- a/files/aria2.conf
+++ b/files/aria2.conf
@@ -15,6 +15,8 @@ continue=true
 max-overall-download-limit=0
 max-overall-upload-limit=1K
 
+disable-ipv6=true
+
 enable-rpc=true
 rpc-listen-all=true
 rpc-allow-origin-all=true

--- a/files/bt-tracker
+++ b/files/bt-tracker
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+url="https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt"
+
+wget --spider "$url" 2>/dev/null
+test $? -eq 0 || exit 1
+
+list="$(wget -qO- "$url" | awk NF | sed ':a;N;s/\n/,/g;ta')"
+
+uuid="$(od -x /dev/urandom | head -1 | awk '{OFS="-" ; print $2$3,$4,$5,$6,$7$8$9}')"
+
+if [ -z "$SECRET" ] && [ -n "$SECRET_FILE" ] && [ -r "$SECRET_FILE" ]; then
+    secret="$(cat "$SECRET_FILE")"
+elif [ -n "$SECRET" ]; then
+    secret="$SECRET"
+fi
+
+json='{"jsonrpc":"2.0","id":"'$uuid'","method":"aria2.changeGlobalOption","params":["token:'$secret'",{"bt-tracker":"'$list'"}]}'
+
+if [ "$SECURE" = "true" ]; then
+    s=s
+fi
+
+curl --silent --insecure --header "Content-type: application/json" --data "$json" "http$s://localhost:6800/jsonrpc"

--- a/files/start.sh
+++ b/files/start.sh
@@ -8,47 +8,41 @@ SEEDRATIO=${SEEDRATIO:=0}
 SEEDTIME=${SEEDTIME:=0}
 IPV6=${IPV6:=false}
 
-if [ ! -f /conf/aria2.conf ]; then
-    cp /preset-conf/aria2.conf /conf/aria2.conf
-    chown $PUID:$PGID /conf/aria2.conf
+conf=/conf/aria2.conf
+if [ ! -f $conf ]; then
+    cp /preset-conf/aria2.conf $conf
+    chown $PUID:$PGID $conf
 
     if [ -z "$SECRET" ] && [ -n "$SECRET_FILE" ] && [ -r "$SECRET_FILE" ]; then
-        echo "rpc-secret=$(cat "${SECRET_FILE}")" >> /conf/aria2.conf
+        echo "rpc-secret=$(cat "$SECRET_FILE")" >> $conf
     elif [ -n "$SECRET" ]; then
-        echo "rpc-secret=${SECRET}" >> /conf/aria2.conf
+        echo "rpc-secret=$SECRET" >> $conf
     fi
 
-    if [ $SECURE = 'true' ]; then
-        echo "" >> /conf/aria2.conf
-        echo "rpc-secure=true" >> /conf/aria2.conf
-        echo "rpc-certificate=$CERTIFICATE" >> /conf/aria2.conf
-        echo "rpc-private-key=$PRIVATEKEY" >> /conf/aria2.conf
+    if [ "$SECURE" = "true" ]; then
+        echo "" >> $conf
+        echo "rpc-secure=true" >> $conf
+        echo "rpc-certificate=$CERTIFICATE" >> $conf
+        echo "rpc-private-key=$PRIVATEKEY" >> $conf
     fi
 
     if [ "$IPV6" = "true" ]; then
-        sed -i "s@disable-ipv6.*@disable-ipv6=false@g" /conf/aria2.conf
+        sed -i "s@disable-ipv6.*@disable-ipv6=false@g" $conf
         ipv6="--ipv6"
     fi
 
     if  [ -n "$FILE_ALLOCATION" ]; then
         case "$FILE_ALLOCATION" in
             none|prealloc|trunc|falloc)
-                echo "" >> /conf/aria2.conf
-                echo "file-allocation=$FILE_ALLOCATION" >> /conf/aria2.conf            
+                echo "" >> $conf
+                echo "file-allocation=$FILE_ALLOCATION" >> $conf            
             ;;
         esac
     fi
         
-    echo "" >> /conf/aria2.conf
-    echo "seed-ratio=$SEEDRATIO" >> /conf/aria2.conf
-    echo "seed-time=$SEEDTIME" >> /conf/aria2.conf
-fi
-
-list=`wget -qO- https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_best.txt|awk NF|sed ":a;N;s/\n/,/g;ta"`
-if [ -z "`grep "bt-tracker" /conf/aria2.conf`" ]; then
-    echo "bt-tracker=$list" >> /conf/aria2.conf
-else
-    sed -i "s@bt-tracker.*@bt-tracker=$list@g" /conf/aria2.conf
+    echo "" >> $conf
+    echo "seed-ratio=$SEEDRATIO" >> $conf
+    echo "seed-time=$SEEDTIME" >> $conf
 fi
 
 chown $PUID:$PGID /conf || echo 'Failed to set owner of /conf, aria2 may not have permission to write /conf/aria2.session'
@@ -59,6 +53,10 @@ chown $PUID:$PGID /conf/aria2.session
 touch /logs.log
 chown $PUID:$PGID /logs.log
 
+crond -l2 -b
+
+( sleep 30 && run-parts /etc/periodic/daily ) &
+
 s6-setuidgid $PUID:$PGID darkhttpd /aria2-ng --port 80 --daemon --no-listing --no-server-id $ipv6
 
-exec s6-setuidgid $PUID:$PGID aria2c --conf-path=/conf/aria2.conf --log=/logs.log
+exec s6-setuidgid $PUID:$PGID aria2c --conf-path=$conf --log=/logs.log

--- a/files/start.sh
+++ b/files/start.sh
@@ -6,6 +6,7 @@ PGID=${PGID:=0}
 SECURE=${SECURE:=false}
 SEEDRATIO=${SEEDRATIO:=0}
 SEEDTIME=${SEEDTIME:=0}
+IPV6=${IPV6:=false}
 
 if [ ! -f /conf/aria2.conf ]; then
     cp /preset-conf/aria2.conf /conf/aria2.conf
@@ -22,6 +23,11 @@ if [ ! -f /conf/aria2.conf ]; then
         echo "rpc-secure=true" >> /conf/aria2.conf
         echo "rpc-certificate=$CERTIFICATE" >> /conf/aria2.conf
         echo "rpc-private-key=$PRIVATEKEY" >> /conf/aria2.conf
+    fi
+
+    if [ "$IPV6" = "true" ]; then
+        sed -i "s@disable-ipv6.*@disable-ipv6=false@g" /conf/aria2.conf
+        ipv6="--ipv6"
     fi
 
     if  [ -n "$FILE_ALLOCATION" ]; then
@@ -53,6 +59,6 @@ chown $PUID:$PGID /conf/aria2.session
 touch /logs.log
 chown $PUID:$PGID /logs.log
 
-darkhttpd /aria2-ng --port 80 &
+darkhttpd /aria2-ng --port 80 $ipv6 &
 
 exec s6-setuidgid $PUID:$PGID aria2c --conf-path=/conf/aria2.conf --log=/logs.log

--- a/files/start.sh
+++ b/files/start.sh
@@ -59,6 +59,6 @@ chown $PUID:$PGID /conf/aria2.session
 touch /logs.log
 chown $PUID:$PGID /logs.log
 
-darkhttpd /aria2-ng --port 80 $ipv6 &
+s6-setuidgid $PUID:$PGID darkhttpd /aria2-ng --port 80 --daemon --no-listing --no-server-id $ipv6
 
 exec s6-setuidgid $PUID:$PGID aria2c --conf-path=/conf/aria2.conf --log=/logs.log


### PR DESCRIPTION
This might be more efficient but does require running crond and adding curl to the image.