### PR TITLE
Fix .netrc file location

### DIFF
--- a/files/aria2.conf
+++ b/files/aria2.conf
@@ -3,10 +3,11 @@ input-file=/conf/aria2.session
 save-session=/conf/aria2.session
 dht-file-path=/conf/dht.dat
 dht-file-path6=/conf/dht6.dat
+netrc-path=/conf/.netrc
 
 log-level=warn
-enable-http-pipelining=true
 
+enable-http-pipelining=true
 max-concurrent-downloads=3
 max-connection-per-server=10
 min-split-size=10M

--- a/files/start.sh
+++ b/files/start.sh
@@ -20,7 +20,6 @@ if [ ! -f $conf ]; then
     fi
 
     if [ "$SECURE" = "true" ]; then
-        echo "" >> $conf
         echo "rpc-secure=true" >> $conf
         echo "rpc-certificate=$CERTIFICATE" >> $conf
         echo "rpc-private-key=$PRIVATEKEY" >> $conf
@@ -47,11 +46,17 @@ fi
 
 chown $PUID:$PGID /conf || echo 'Failed to set owner of /conf, aria2 may not have permission to write /conf/aria2.session'
 
-touch /conf/aria2.session
-chown $PUID:$PGID /conf/aria2.session
+touch \
+    /conf/aria2.session \
+    /conf/.netrc \
+    /logs.log
 
-touch /logs.log
-chown $PUID:$PGID /logs.log
+chown $PUID:$PGID \
+    /conf/aria2.session \
+    /conf/.netrc \
+    /logs.log
+
+chmod 600 /conf/.netrc
 
 crond -l2 -b
 


### PR DESCRIPTION
Set netrc-path to /conf/.netrc because the default (/root/.netrc) is inaccessible to aria2c when not running as root.


Sorry, I forgot about this when I submitted the last pull request.

I'm glad your happy with the changes I've made so far.

This will probably be the last one for now.