### PR TITLE
Stop aria2c spamming the docker log

### DIFF
--- a/files/aria2.conf
+++ b/files/aria2.conf
@@ -5,7 +5,7 @@ dht-file-path=/conf/dht.dat
 dht-file-path6=/conf/dht6.dat
 netrc-path=/conf/.netrc
 
-log-level=warn
+log-level=notice
 
 enable-http-pipelining=true
 max-concurrent-downloads=3

--- a/files/start.sh
+++ b/files/start.sh
@@ -49,12 +49,12 @@ chown $PUID:$PGID /conf || echo 'Failed to set owner of /conf, aria2 may not hav
 touch \
     /conf/aria2.session \
     /conf/.netrc \
-    /logs.log
+    /conf/aria2.log
 
 chown $PUID:$PGID \
     /conf/aria2.session \
     /conf/.netrc \
-    /logs.log
+    /conf/aria2.log
 
 chmod 600 /conf/.netrc
 
@@ -64,4 +64,4 @@ crond -l2 -b
 
 s6-setuidgid $PUID:$PGID darkhttpd /aria2-ng --port 80 --daemon --no-listing --no-server-id $ipv6
 
-exec s6-setuidgid $PUID:$PGID aria2c --conf-path=$conf --log=/logs.log
+exec s6-setuidgid $PUID:$PGID aria2c --conf-path=$conf --log=/conf/aria2.log >/dev/null 2>&1


### PR DESCRIPTION
Raised log level to notice, moved log file to /conf and redirected console output from aria2c to /dev/null.

This stops aria2c constantly writing to stdout and filling the docker log with empty lines.


One more.